### PR TITLE
Neofetch CPU temperature fix

### DIFF
--- a/ansible/roles/user/files/neofetch.conf
+++ b/ansible/roles/user/files/neofetch.conf
@@ -5,7 +5,7 @@ print_info() {
     info title
     info "Uptime" uptime
     info "CPU Usage" cpu_usage
-    prin "CPU Temp" "$(/opt/vc/bin/vcgencmd measure_temp|awk -F "=" '{print $2}')"
+    prin "CPU Temp" "$(cat /sys/class/thermal/thermal_zone*/temp | sed 's/\(.\)..$/.\1°C/')"
     info "Memory Usage" memory
     info "Disk" disk
     info "Local IP" local_ip


### PR DESCRIPTION
For Ubuntu `/opt/vc/bin/vcgencmd measure_temp` doesn't work. But getting it from thermal zone is just fine.